### PR TITLE
feat: adds lookup methods for neighboring functionalities

### DIFF
--- a/src/functionalities/Functionality.js
+++ b/src/functionalities/Functionality.js
@@ -157,6 +157,12 @@ class Functionality {
     return this._getConnectedFcts(this.outSlots)
   }
 
+  getConnectedFctsByName(targetName) {
+    return this.connectedFcts.filter(({ name }) => (
+      targetName === name
+    ))
+  }
+
 }
 
 module.exports = Functionality

--- a/src/functionalities/OutputNode.js
+++ b/src/functionalities/OutputNode.js
@@ -51,6 +51,16 @@ class OutputNode extends Functionality {
     }
   }
 
+  get source() {
+    const { sources, name } = this
+
+    if (sources.length > 1) {
+      throw new Error(`Output Node: ${name} has more than one connected fct. Output nodes may only have one source. Current sources: ${sources}`)
+    }
+
+    return sources[0]
+  }
+
 }
 
 module.exports = OutputNode

--- a/src/seeders/functionalities/PushOutSeeder.js
+++ b/src/seeders/functionalities/PushOutSeeder.js
@@ -22,9 +22,12 @@ class PushOutSeeder extends OutputNodeSeeder {
     }
   }
 
-  static generateFloatPushOutCelsius() {
+  static generateFloatPushOutCelsius(overrideData) {
     return this.generate({
-      slots: [ FloatInSlotSeeder.generate({ unit: '°C' }) ],
+      slots: [
+        FloatInSlotSeeder.generate({ name: 'value in', unit: '°C' }),
+      ],
+      ...overrideData,
     })
   }
 

--- a/test/functionalities/Functionality.test.js
+++ b/test/functionalities/Functionality.test.js
@@ -3,6 +3,7 @@ const {
   HeaterActuatorSeeder,
   PIDControllerSeeder,
   TemperatureSensorSeeder,
+  PushOutSeeder,
 } = require('seeders/functionalities')
 const {
   FloatInSlotSeeder,
@@ -54,82 +55,139 @@ describe('the Functionality class', () => {
   })
 
   describe('getting connected fcts', () => {
-    it('.connectedFcts returns all connected fcts', () => {
-      const heater = HeaterActuatorSeeder.seedOne(
-        HeaterActuatorSeeder.generateCelsiusHeater(),
-      )
-      const pidController = PIDControllerSeeder.seedOne(
-        PIDControllerSeeder.generateTemperatureControllerCelsius(),
-      )
-      const tempSensor = TemperatureSensorSeeder.seedOne(
-        TemperatureSensorSeeder.generateCelsiusFloatProducer(),
-      )
+    describe('.connectedFcts', () => {
+      it('returns all connected fcts', () => {
+        const heater = HeaterActuatorSeeder.seedOne(
+          HeaterActuatorSeeder.generateCelsiusHeater(),
+        )
+        const pidController = PIDControllerSeeder.seedOne(
+          PIDControllerSeeder.generateTemperatureControllerCelsius(),
+        )
+        const tempSensor = TemperatureSensorSeeder.seedOne(
+          TemperatureSensorSeeder.generateCelsiusFloatProducer(),
+        )
 
-      expect(tempSensor.connectedFcts).toHaveLength(0)
-      expect(heater.connectedFcts).toHaveLength(0)
-      expect(pidController.connectedFcts).toHaveLength(0)
+        expect(tempSensor.connectedFcts).toHaveLength(0)
+        expect(heater.connectedFcts).toHaveLength(0)
+        expect(pidController.connectedFcts).toHaveLength(0)
 
-      tempSensor.outSlots[0].connectTo(pidController.getSlotByName('value in'))
+        tempSensor.outSlots[0].connectTo(pidController.getSlotByName('value in'))
 
-      expect(heater.connectedFcts).toHaveLength(0)
-      expect(tempSensor.connectedFcts).toHaveLength(1)
-      expect(pidController.connectedFcts).toHaveLength(1)
-      expect(tempSensor.connectedFcts[0]).toBe(pidController)
-      expect(pidController.connectedFcts[0]).toBe(tempSensor)
+        expect(heater.connectedFcts).toHaveLength(0)
+        expect(tempSensor.connectedFcts).toHaveLength(1)
+        expect(pidController.connectedFcts).toHaveLength(1)
+        expect(tempSensor.connectedFcts[0]).toBe(pidController)
+        expect(pidController.connectedFcts[0]).toBe(tempSensor)
 
-      pidController.outSlots[0].connectTo(heater.inSlots[0])
+        pidController.outSlots[0].connectTo(heater.inSlots[0])
 
-      expect(heater.connectedFcts).toHaveLength(1)
-      expect(tempSensor.connectedFcts).toHaveLength(1)
-      expect(pidController.connectedFcts).toHaveLength(2)
-      expect(heater.connectedFcts[0]).toBe(pidController)
-      expect(pidController.connectedFcts).toStrictEqual([
-        tempSensor, heater,
-      ])
+        expect(heater.connectedFcts).toHaveLength(1)
+        expect(tempSensor.connectedFcts).toHaveLength(1)
+        expect(pidController.connectedFcts).toHaveLength(2)
+        expect(heater.connectedFcts[0]).toBe(pidController)
+        expect(pidController.connectedFcts).toStrictEqual([
+          tempSensor, heater,
+        ])
+      })
     })
 
-    it('.sources returns all fcts connected via inslots', () => {
-      const heater = HeaterActuatorSeeder.seedOne(
-        HeaterActuatorSeeder.generateCelsiusHeater(),
-      )
-      const pidController = PIDControllerSeeder.seedOne(
-        PIDControllerSeeder.generateTemperatureControllerCelsius(),
-      )
-      const tempSensor = TemperatureSensorSeeder.seedOne(
-        TemperatureSensorSeeder.generateCelsiusFloatProducer(),
-      )
+    describe('.sources', () => {
+      it('all fcts connected via inslots', () => {
+        const heater = HeaterActuatorSeeder.seedOne(
+          HeaterActuatorSeeder.generateCelsiusHeater(),
+        )
+        const pidController = PIDControllerSeeder.seedOne(
+          PIDControllerSeeder.generateTemperatureControllerCelsius(),
+        )
+        const tempSensor = TemperatureSensorSeeder.seedOne(
+          TemperatureSensorSeeder.generateCelsiusFloatProducer(),
+        )
 
-      tempSensor.outSlots[0].connectTo(pidController.getSlotByName('value in'))
-      pidController.outSlots[0].connectTo(heater.inSlots[0])
+        tempSensor.outSlots[0].connectTo(pidController.getSlotByName('value in'))
+        pidController.outSlots[0].connectTo(heater.inSlots[0])
 
-      expect(pidController.sources).toStrictEqual([ tempSensor ])
-      expect(heater.sources).toStrictEqual([ pidController ])
+        expect(pidController.sources).toStrictEqual([ tempSensor ])
+        expect(heater.sources).toStrictEqual([ pidController ])
+      })
     })
 
-    it('.sinks returns all fcts connected via outslots', () => {
-      const heaterA = HeaterActuatorSeeder.seedOne(
-        HeaterActuatorSeeder.generateCelsiusHeater(),
-      )
-      const heaterB = HeaterActuatorSeeder.seedOne(
-        HeaterActuatorSeeder.generateCelsiusHeater(),
-      )
-      const pidController = PIDControllerSeeder.seedOne(
-        PIDControllerSeeder.generateTemperatureControllerCelsius(),
-      )
-      const tempSensor = TemperatureSensorSeeder.seedOne(
-        TemperatureSensorSeeder.generateCelsiusFloatProducer(),
-      )
+    describe('.sinks', () => {
+      it('returns all fcts connected via outslots', () => {
+        const heaterA = HeaterActuatorSeeder.seedOne(
+          HeaterActuatorSeeder.generateCelsiusHeater(),
+        )
+        const heaterB = HeaterActuatorSeeder.seedOne(
+          HeaterActuatorSeeder.generateCelsiusHeater(),
+        )
+        const pidController = PIDControllerSeeder.seedOne(
+          PIDControllerSeeder.generateTemperatureControllerCelsius(),
+        )
+        const tempSensor = TemperatureSensorSeeder.seedOne(
+          TemperatureSensorSeeder.generateCelsiusFloatProducer(),
+        )
 
-      tempSensor.outSlots[0].connectTo(pidController.getSlotByName('value in'))
-      pidController.outSlots[0].connectTo(heaterA.inSlots[0])
-      pidController.outSlots[0].connectTo(heaterB.inSlots[0])
+        tempSensor.outSlots[0].connectTo(pidController.getSlotByName('value in'))
+        pidController.outSlots[0].connectTo(heaterA.inSlots[0])
+        pidController.outSlots[0].connectTo(heaterB.inSlots[0])
 
-      expect(tempSensor.sinks).toStrictEqual([ pidController ])
-      expect(heaterA.sinks).toStrictEqual([])
-      expect(pidController.sinks).toStrictEqual([
-        heaterA, heaterB,
-      ])
+        expect(tempSensor.sinks).toStrictEqual([ pidController ])
+        expect(heaterA.sinks).toStrictEqual([])
+        expect(pidController.sinks).toStrictEqual([
+          heaterA, heaterB,
+        ])
+      })
     })
+
+    describe('getConnectedFctsByName', () => {
+      it('returns all fcts connected that match the specific name', () => {
+        const CONTROLLER_NAME = 'pid controller'
+        const REPORTER_NAME = 'web reporter'
+
+        const tempSensorA = TemperatureSensorSeeder.seedOne(
+          TemperatureSensorSeeder.generateCelsiusFloatProducer(),
+        )
+        const tempSensorB = TemperatureSensorSeeder.seedOne(
+          TemperatureSensorSeeder.generateCelsiusFloatProducer(),
+        )
+        const pidControllerA1 = PIDControllerSeeder.seedOne(
+          PIDControllerSeeder.generateTemperatureControllerCelsius({ name: CONTROLLER_NAME }),
+        )
+        const pidControllerA2 = PIDControllerSeeder.seedOne(
+          PIDControllerSeeder.generateTemperatureControllerCelsius({ name: CONTROLLER_NAME }),
+        )
+        const pidControllerB1 = PIDControllerSeeder.seedOne(
+          PIDControllerSeeder.generateTemperatureControllerCelsius({ name: CONTROLLER_NAME }),
+        )
+        const webReporterA1 = PushOutSeeder.seedOne(
+          PushOutSeeder.generateFloatPushOutCelsius({ name: REPORTER_NAME }),
+        )
+        const webReporterA2 = PushOutSeeder.seedOne(
+          PushOutSeeder.generateFloatPushOutCelsius({ name: REPORTER_NAME }),
+        )
+
+        tempSensorA.outSlots[0].connectTo(pidControllerA1.getSlotByName('value in'))
+        tempSensorA.outSlots[0].connectTo(pidControllerA2.getSlotByName('value in'))
+        tempSensorA.outSlots[0].connectTo(webReporterA1.getSlotByName('value in'))
+        tempSensorA.outSlots[0].connectTo(webReporterA2.getSlotByName('value in'))
+
+        tempSensorB.outSlots[0].connectTo(pidControllerB1.getSlotByName('value in'))
+
+        expect(tempSensorA.getConnectedFctsByName(CONTROLLER_NAME)).toStrictEqual([
+          pidControllerA1,
+          pidControllerA2,
+        ])
+
+        expect(tempSensorA.getConnectedFctsByName(REPORTER_NAME)).toStrictEqual([
+          webReporterA1,
+          webReporterA2,
+        ])
+
+        expect(tempSensorB.getConnectedFctsByName(CONTROLLER_NAME)).toStrictEqual([
+          pidControllerB1,
+        ])
+      })
+    })
+
   })
 
 })


### PR DESCRIPTION
adds two methods since they are being used in multiple PRs:

`functionality.getConnectedFctsByName`

`outputNode.source` (`OutputNode` is the base class of `PushOut`, aka web reporters)