### PR TITLE
fix: Update Controller Seeder

### DIFF
--- a/src/seeders/functionalities/PIDControllerSeeder.js
+++ b/src/seeders/functionalities/PIDControllerSeeder.js
@@ -1,14 +1,14 @@
 const ControllerSeeder = require('./ControllerSeeder')
-const { InSlotSeeder,FloatInSlotSeeder, FloatOutSlotSeeder } = require('../slots')
+const { FloatInSlotSeeder, FloatOutSlotSeeder } = require('../slots')
 const PIDController = require('../../functionalities/PIDController')
 
 class PIDControllerSeeder extends ControllerSeeder {
 
   static generateSlots() {
     return [
-      InSlotSeeder.generateControllerParameterSlot({ name: 'P' }),
-      InSlotSeeder.generateControllerParameterSlot({ name: 'I' }),
-      InSlotSeeder.generateControllerParameterSlot({ name: 'D' }),
+      FloatInSlotSeeder.generateControllerParameterSlot({ name: 'P' }),
+      FloatInSlotSeeder.generateControllerParameterSlot({ name: 'I' }),
+      FloatInSlotSeeder.generateControllerParameterSlot({ name: 'D' }),
       FloatInSlotSeeder.generate({ name: 'target in' }),
       FloatInSlotSeeder.generate({ name: 'value in' }),
       FloatOutSlotSeeder.generate({ name: 'value out' }),
@@ -29,9 +29,10 @@ class PIDControllerSeeder extends ControllerSeeder {
    * **************************************************************** */
   static generateTemperatureControllerCelsius(data) {
     const slots = [
-      InSlotSeeder.generateControllerParameterSlot({ name: 'P' }),
-      InSlotSeeder.generateControllerParameterSlot({ name: 'I' }),
-      InSlotSeeder.generateControllerParameterSlot({ name: 'D' }),
+      FloatInSlotSeeder.generateControllerParameterSlot({ name: 'P' }),
+      FloatInSlotSeeder.generateControllerParameterSlot({ name: 'I' }),
+      FloatInSlotSeeder.generateControllerParameterSlot({ name: 'D' }),
+      FloatInSlotSeeder.generateCelsiusIn({ name: 'target in' }),
       FloatInSlotSeeder.generateCelsiusIn({ name: 'value in' }),
       FloatOutSlotSeeder.generateCelsiusOut({ name: 'value out' }),
     ]

--- a/src/seeders/functionalities/PIDControllerSeeder.js
+++ b/src/seeders/functionalities/PIDControllerSeeder.js
@@ -1,14 +1,14 @@
 const ControllerSeeder = require('./ControllerSeeder')
-const { FloatInSlotSeeder, FloatOutSlotSeeder } = require('../slots')
+const { InSlotSeeder,FloatInSlotSeeder, FloatOutSlotSeeder } = require('../slots')
 const PIDController = require('../../functionalities/PIDController')
 
 class PIDControllerSeeder extends ControllerSeeder {
 
   static generateSlots() {
     return [
-      FloatInSlotSeeder.generateUnitlessIn({ name: 'P' }),
-      FloatInSlotSeeder.generateUnitlessIn({ name: 'I' }),
-      FloatInSlotSeeder.generateUnitlessIn({ name: 'D' }),
+      InSlotSeeder.generateControllerParameterSlot({ name: 'P' }),
+      InSlotSeeder.generateControllerParameterSlot({ name: 'I' }),
+      InSlotSeeder.generateControllerParameterSlot({ name: 'D' }),
       FloatInSlotSeeder.generate({ name: 'target in' }),
       FloatInSlotSeeder.generate({ name: 'value in' }),
       FloatOutSlotSeeder.generate({ name: 'value out' }),
@@ -29,9 +29,9 @@ class PIDControllerSeeder extends ControllerSeeder {
    * **************************************************************** */
   static generateTemperatureControllerCelsius(data) {
     const slots = [
-      FloatInSlotSeeder.generateUnitlessIn({ name: 'P' }),
-      FloatInSlotSeeder.generateUnitlessIn({ name: 'I' }),
-      FloatInSlotSeeder.generateUnitlessIn({ name: 'D' }),
+      InSlotSeeder.generateControllerParameterSlot({ name: 'P' }),
+      InSlotSeeder.generateControllerParameterSlot({ name: 'I' }),
+      InSlotSeeder.generateControllerParameterSlot({ name: 'D' }),
       FloatInSlotSeeder.generateCelsiusIn({ name: 'value in' }),
       FloatOutSlotSeeder.generateCelsiusOut({ name: 'value out' }),
     ]

--- a/src/seeders/functionalities/PIDControllerSeeder.js
+++ b/src/seeders/functionalities/PIDControllerSeeder.js
@@ -6,9 +6,9 @@ class PIDControllerSeeder extends ControllerSeeder {
 
   static generateSlots() {
     return [
-      FloatInSlotSeeder.generateControllerParameterSlot({ name: 'P' }),
-      FloatInSlotSeeder.generateControllerParameterSlot({ name: 'I' }),
-      FloatInSlotSeeder.generateControllerParameterSlot({ name: 'D' }),
+      FloatInSlotSeeder.generatePIDControllerParameterSlot({ name: 'P' }),
+      FloatInSlotSeeder.generatePIDControllerParameterSlot({ name: 'I' }),
+      FloatInSlotSeeder.generatePIDControllerParameterSlot({ name: 'D' }),
       FloatInSlotSeeder.generate({ name: 'target in' }),
       FloatInSlotSeeder.generate({ name: 'value in' }),
       FloatOutSlotSeeder.generate({ name: 'value out' }),
@@ -29,9 +29,9 @@ class PIDControllerSeeder extends ControllerSeeder {
    * **************************************************************** */
   static generateTemperatureControllerCelsius(data) {
     const slots = [
-      FloatInSlotSeeder.generateControllerParameterSlot({ name: 'P' }),
-      FloatInSlotSeeder.generateControllerParameterSlot({ name: 'I' }),
-      FloatInSlotSeeder.generateControllerParameterSlot({ name: 'D' }),
+      FloatInSlotSeeder.generatePIDControllerParameterSlot({ name: 'P' }),
+      FloatInSlotSeeder.generatePIDControllerParameterSlot({ name: 'I' }),
+      FloatInSlotSeeder.generatePIDControllerParameterSlot({ name: 'D' }),
       FloatInSlotSeeder.generateCelsiusIn({ name: 'target in' }),
       FloatInSlotSeeder.generateCelsiusIn({ name: 'value in' }),
       FloatOutSlotSeeder.generateCelsiusOut({ name: 'value out' }),

--- a/src/seeders/slots/InSlotSeeder.js
+++ b/src/seeders/slots/InSlotSeeder.js
@@ -35,6 +35,12 @@ class InSlotSeeder extends SlotSeeder {
     })
   }
 
+  static generateControllerParameterSlot(data) {
+    return this.generateUnitlessIn(
+      { ...data, displayType: InSlot.CONTROLLER_PARAMETER_DISPLAY_TYPE },
+    )
+  }
+
   static seedCelsiusIn(data) {
     return this.seedOne(
       this.generateCelsiusIn(data),

--- a/src/seeders/slots/InSlotSeeder.js
+++ b/src/seeders/slots/InSlotSeeder.js
@@ -3,6 +3,10 @@ const SlotSeeder = require('./SlotSeeder')
 
 class InSlotSeeder extends SlotSeeder {
 
+  static get DISPLAY_TYPES() {
+    return [...super.DISPLAY_TYPES, InSlot.CONTROLLER_PARAMETER_DISPLAY_TYPE]
+  }
+
   static generate(data = {}) {
     return {
       ...super.generate(data),

--- a/src/seeders/slots/InSlotSeeder.js
+++ b/src/seeders/slots/InSlotSeeder.js
@@ -39,7 +39,7 @@ class InSlotSeeder extends SlotSeeder {
     })
   }
 
-  static generateControllerParameterSlot(data) {
+  static generatePIDControllerParameterSlot(data) {
     return this.generateUnitlessIn(
       { ...data, displayType: InSlot.CONTROLLER_PARAMETER_DISPLAY_TYPE },
     )

--- a/src/seeders/slots/SlotSeeder.js
+++ b/src/seeders/slots/SlotSeeder.js
@@ -13,7 +13,6 @@ class SlotSeeder {
       'temperature',
       'switch',
       'flow',
-      'controller parameter',
     ]
   }
 

--- a/src/slots/InSlot.js
+++ b/src/slots/InSlot.js
@@ -9,10 +9,15 @@ class InSlot extends Slot {
     return 'InSlot'
   }
 
+  static get CONTROLLER_PARAMETER_DISPLAY_TYPE() {
+    return 'controller parameter'
+  }
+
   static get SCHEMA() {
     return super.SCHEMA.concat(Joi.object({
       type: Joi.string().allow(InSlot.TYPE).required(),
       dataStreams: super.SCHEMA.extract('dataStreams').max(1),
+      displayType: super.SCHEMA.extract('displayType').allow(InSlot.CONTROLLER_PARAMETER_DISPLAY_TYPE),
     }))
   }
 
@@ -28,6 +33,10 @@ class InSlot extends Slot {
     }
 
     return dataObj
+  }
+
+  get isControllerParameter() {
+    return this.displayType === InSlot.CONTROLLER_PARAMETER_DISPLAY_TYPE
   }
 
   _assertHasRoomForConnectionTo(otherSlot) {

--- a/src/slots/InSlot.js
+++ b/src/slots/InSlot.js
@@ -17,7 +17,7 @@ class InSlot extends Slot {
     return super.SCHEMA.concat(Joi.object({
       type: Joi.string().allow(InSlot.TYPE).required(),
       dataStreams: super.SCHEMA.extract('dataStreams').max(1),
-      displayType: super.SCHEMA.extract('displayType').allow(InSlot.CONTROLLER_PARAMETER_DISPLAY_TYPE),
+      displayType: super.SCHEMA.extract('displayType'),
     }))
   }
 

--- a/test/fctGraph/FCTGraph.test.js
+++ b/test/fctGraph/FCTGraph.test.js
@@ -16,6 +16,7 @@ const { FloatInSlotSeeder, FloatOutSlotSeeder } = require('seeders/slots')
 const FCTGraph = require('fctGraph/FCTGraph')
 const DataStream = require('dataStreams/DataStream')
 const connectedFCTGraphData = require('./seeds/connectedFCTGraphData')
+const connectedPIDFCTGraphData = require('./seeds/connectedPIDFctGraphData')
 
 describe('the FCTGraph class', () => {
 
@@ -59,6 +60,18 @@ describe('the FCTGraph class', () => {
         const fctGraph = new FCTGraph(connectedFCTGraphData)
 
         expect(fctGraph.dataStreamsCount).toBe(85)
+      })
+    })
+
+    describe('when given a connected PID FctGraph', () => {
+      it('should serialize the FCTGraph', () => {
+        const fctGraph = new FCTGraph(connectedPIDFCTGraphData)
+        expect(fctGraph instanceof FCTGraph).toBe(true)
+      })
+
+      it('should populate the datastreams', () => {
+        const fctGraph = new FCTGraph(connectedPIDFCTGraphData)
+        expect(fctGraph.dataStreamsCount).toBe(6)
       })
     })
   })

--- a/test/fctGraph/seeds/connectedPIDFctGraphData.js
+++ b/test/fctGraph/seeds/connectedPIDFctGraphData.js
@@ -1,0 +1,312 @@
+/* eslint-disable */
+module.exports = {
+  "deviceDefault":false,
+  "deviceId":"c1d5722b-4449-46a0-99a2-052a6bda1926",
+  "functionalities":[
+     {
+        "id":"3243a72d-6d3b-45b6-9be5-5489ba305c62",
+        "isVirtual":false,
+        "name":"circuit",
+        "slots":[
+           {
+              "dataStreams":[
+                 {
+                    "averagingWindowSize":0,
+                    "id":"b8eb71c2-df5d-4d1d-9830-9a21c5b6989c",
+                    "sinkFctId":"13504539-93f3-4b2b-a072-f31a5453d118",
+                    "sinkSlotName":"value in",
+                    "sourceFctId":"3243a72d-6d3b-45b6-9be5-5489ba305c62",
+                    "sourceSlotName":"Celsius Out"
+                 }
+              ],
+              "dataType":"float",
+              "displayType":"temperature",
+              "name":"Celsius Out",
+              "type":"OutSlot",
+              "unit":"°C"
+           }
+        ],
+        "subType":"TemperatureSensor",
+        "type":"Sensor"
+     },
+     {
+        "id":"13504539-93f3-4b2b-a072-f31a5453d118",
+        "isVirtual":false,
+        "name":"TemperaturePIDController",
+        "slots":[
+           {
+              "dataStreams":[
+                 {
+                    "averagingWindowSize":0,
+                    "id":"7c050871-38f4-4c03-a307-ff1cd12ff5af",
+                    "sinkFctId":"13504539-93f3-4b2b-a072-f31a5453d118",
+                    "sinkSlotName":"P",
+                    "sourceFctId":"9dddc7f0-3658-462b-a6cd-00cce8e0dcdb",
+                    "sourceSlotName":"P"
+                 }
+              ],
+              "dataType":"float",
+              "defaultValue":-33.06,
+              "displayType":"controller parameter",
+              "max":54.92,
+              "min":-40.61,
+              "name":"P",
+              "tareable":true,
+              "type":"InSlot",
+              "unit":"-"
+           },
+           {
+              "dataStreams":[
+                 {
+                    "averagingWindowSize":0,
+                    "id":"929bcf4f-eb83-4884-a1cc-2a95994e49de",
+                    "sinkFctId":"13504539-93f3-4b2b-a072-f31a5453d118",
+                    "sinkSlotName":"I",
+                    "sourceFctId":"3a341065-02f7-40bf-9976-9ce20b0239dc",
+                    "sourceSlotName":"I"
+                 }
+              ],
+              "dataType":"float",
+              "defaultValue":58.65,
+              "displayType":"controller parameter",
+              "max":110.35,
+              "min":-3.37,
+              "name":"I",
+              "tareable":true,
+              "type":"InSlot",
+              "unit":"-"
+           },
+           {
+              "dataStreams":[
+                 {
+                    "averagingWindowSize":0,
+                    "id":"c6753331-df1a-497a-bfc7-ebe12b57a931",
+                    "sinkFctId":"13504539-93f3-4b2b-a072-f31a5453d118",
+                    "sinkSlotName":"D",
+                    "sourceFctId":"9b988373-b23c-4375-b2e8-962c470298f7",
+                    "sourceSlotName":"D"
+                 }
+              ],
+              "dataType":"float",
+              "defaultValue":-33.82,
+              "displayType":"controller parameter",
+              "max":36.57,
+              "min":-74.01,
+              "name":"D",
+              "tareable":true,
+              "type":"InSlot",
+              "unit":"-"
+           },
+           {
+              "dataStreams":[
+                 {
+                    "averagingWindowSize":0,
+                    "id":"47874b3d-836f-481b-8872-edc1f4ddc7a7",
+                    "sinkFctId":"13504539-93f3-4b2b-a072-f31a5453d118",
+                    "sinkSlotName":"target in",
+                    "sourceFctId":"2ad9cb7c-f40a-4cd1-9793-7f51effba459",
+                    "sourceSlotName":"target in"
+                 }
+              ],
+              "dataType":"float",
+              "defaultValue":10.38,
+              "displayType":"temperature",
+              "max":82.99,
+              "min":-27.16,
+              "name":"target in",
+              "tareable":true,
+              "type":"InSlot",
+              "unit":"°C"
+           },
+           {
+              "dataStreams":[
+                 {
+                    "averagingWindowSize":0,
+                    "id":"b8eb71c2-df5d-4d1d-9830-9a21c5b6989c",
+                    "sinkFctId":"13504539-93f3-4b2b-a072-f31a5453d118",
+                    "sinkSlotName":"value in",
+                    "sourceFctId":"3243a72d-6d3b-45b6-9be5-5489ba305c62",
+                    "sourceSlotName":"Celsius Out"
+                 }
+              ],
+              "dataType":"float",
+              "defaultValue":54.35,
+              "displayType":"flow",
+              "max":74.03,
+              "min":9.59,
+              "name":"value in",
+              "tareable":false,
+              "type":"InSlot",
+              "unit":"°C"
+           },
+           {
+              "dataStreams":[
+                 {
+                    "averagingWindowSize":0,
+                    "id":"4a8cda58-fce5-45dd-a977-bb58c44357f4",
+                    "sinkFctId":"65a769b5-da80-4421-8370-3f1ce531b48a",
+                    "sinkSlotName":"Celsius In",
+                    "sourceFctId":"13504539-93f3-4b2b-a072-f31a5453d118",
+                    "sourceSlotName":"value out"
+                 }
+              ],
+              "dataType":"float",
+              "displayType":"temperature",
+              "name":"value out",
+              "type":"OutSlot",
+              "unit":"°C"
+           }
+        ],
+        "subType":"PIDController",
+        "type":"Controller"
+     },
+     {
+        "id":"65a769b5-da80-4421-8370-3f1ce531b48a",
+        "isVirtual":false,
+        "name":"Celsius Heater",
+        "slots":[
+           {
+              "dataStreams":[
+                 {
+                    "averagingWindowSize":0,
+                    "id":"4a8cda58-fce5-45dd-a977-bb58c44357f4",
+                    "sinkFctId":"65a769b5-da80-4421-8370-3f1ce531b48a",
+                    "sinkSlotName":"Celsius In",
+                    "sourceFctId":"13504539-93f3-4b2b-a072-f31a5453d118",
+                    "sourceSlotName":"value out"
+                 }
+              ],
+              "dataType":"float",
+              "defaultValue":30.51,
+              "displayType":"flow",
+              "max":78.54,
+              "min":-35.03,
+              "name":"Celsius In",
+              "tareable":false,
+              "type":"InSlot",
+              "unit":"°C"
+           }
+        ],
+        "subType":"HeaterActuator",
+        "type":"Actuator"
+     },
+     {
+        "id":"9dddc7f0-3658-462b-a6cd-00cce8e0dcdb",
+        "isVirtual":true,
+        "name":"Push In",
+        "slots":[
+           {
+              "dataStreams":[
+                 {
+                    "averagingWindowSize":0,
+                    "id":"7c050871-38f4-4c03-a307-ff1cd12ff5af",
+                    "sinkFctId":"13504539-93f3-4b2b-a072-f31a5453d118",
+                    "sinkSlotName":"P",
+                    "sourceFctId":"9dddc7f0-3658-462b-a6cd-00cce8e0dcdb",
+                    "sourceSlotName":"P"
+                 }
+              ],
+              "dataType":"float",
+              "displayType":"controller parameter",
+              "name":"P",
+              "type":"OutSlot",
+              "unit":"-"
+           }
+        ],
+        "source":{
+           "name":"ospin-webapp"
+        },
+        "subType":"PushIn",
+        "type":"InputNode"
+     },
+     {
+        "id":"3a341065-02f7-40bf-9976-9ce20b0239dc",
+        "isVirtual":true,
+        "name":"Push In",
+        "slots":[
+           {
+              "dataStreams":[
+                 {
+                    "averagingWindowSize":0,
+                    "id":"929bcf4f-eb83-4884-a1cc-2a95994e49de",
+                    "sinkFctId":"13504539-93f3-4b2b-a072-f31a5453d118",
+                    "sinkSlotName":"I",
+                    "sourceFctId":"3a341065-02f7-40bf-9976-9ce20b0239dc",
+                    "sourceSlotName":"I"
+                 }
+              ],
+              "dataType":"float",
+              "displayType":"controller parameter",
+              "name":"I",
+              "type":"OutSlot",
+              "unit":"-"
+           }
+        ],
+        "source":{
+           "name":"ospin-webapp"
+        },
+        "subType":"PushIn",
+        "type":"InputNode"
+     },
+     {
+        "id":"9b988373-b23c-4375-b2e8-962c470298f7",
+        "isVirtual":true,
+        "name":"Push In",
+        "slots":[
+           {
+              "dataStreams":[
+                 {
+                    "averagingWindowSize":0,
+                    "id":"c6753331-df1a-497a-bfc7-ebe12b57a931",
+                    "sinkFctId":"13504539-93f3-4b2b-a072-f31a5453d118",
+                    "sinkSlotName":"D",
+                    "sourceFctId":"9b988373-b23c-4375-b2e8-962c470298f7",
+                    "sourceSlotName":"D"
+                 }
+              ],
+              "dataType":"float",
+              "displayType":"controller parameter",
+              "name":"D",
+              "type":"OutSlot",
+              "unit":"-"
+           }
+        ],
+        "source":{
+           "name":"ospin-webapp"
+        },
+        "subType":"PushIn",
+        "type":"InputNode"
+     },
+     {
+        "id":"2ad9cb7c-f40a-4cd1-9793-7f51effba459",
+        "isVirtual":true,
+        "name":"Push In",
+        "slots":[
+           {
+              "dataStreams":[
+                 {
+                    "averagingWindowSize":0,
+                    "id":"47874b3d-836f-481b-8872-edc1f4ddc7a7",
+                    "sinkFctId":"13504539-93f3-4b2b-a072-f31a5453d118",
+                    "sinkSlotName":"target in",
+                    "sourceFctId":"2ad9cb7c-f40a-4cd1-9793-7f51effba459",
+                    "sourceSlotName":"target in"
+                 }
+              ],
+              "dataType":"float",
+              "displayType":"temperature",
+              "name":"target in",
+              "type":"OutSlot",
+              "unit":"°C"
+           }
+        ],
+        "source":{
+           "name":"ospin-webapp"
+        },
+        "subType":"PushIn",
+        "type":"InputNode"
+     }
+  ],
+  "id":"22c45426-711b-45af-bc60-e2f711d68c6a",
+  "name":"Dynamic"
+}

--- a/test/slots/FloatInSlot.test.js
+++ b/test/slots/FloatInSlot.test.js
@@ -42,11 +42,6 @@ describe('the FloatInSlot class', () => {
 
       expect(() => FloatInSlot.newAndAssertStructure(slotData)).toThrow(/min/)
     })
-
-    it('should allow for the display type "controller parameter"', () => {
-      const slotData = FloatInSlotSeeder.generate({ displayType: 'controller parameter' })
-      expect(() => FloatInSlot.newAndAssertStructure(slotData)).not.toThrow()
-    });
   })
 
   describe('.constructor', () => {

--- a/test/slots/FloatInSlot.test.js
+++ b/test/slots/FloatInSlot.test.js
@@ -104,4 +104,17 @@ describe('the FloatInSlot class', () => {
     })
 
   })
+
+  describe('.isControllerParameter', () => {
+    it('should return true for slots with the displayType controller paramter', () => {
+      const slot1 = new FloatInSlot(
+        FloatInSlotSeeder.generate({ displayType: FloatInSlot.CONTROLLER_PARAMETER_DISPLAY_TYPE }),
+      )
+      const slot2 = new FloatInSlot(FloatInSlotSeeder.generate({ displayType: 'temperature' }))
+
+      expect(slot1.isControllerParameter).toBe(true)
+      expect(slot2.isControllerParameter).toBe(false)
+
+    });
+  })
 })

--- a/test/slots/FloatInSlot.test.js
+++ b/test/slots/FloatInSlot.test.js
@@ -1,6 +1,7 @@
 const FloatInSlot = require('slots/FloatInSlot')
 const { FloatInSlotSeeder } = require('seeders/slots')
 const DataStreamSeeder = require('seeders/dataStreams/DataStreamSeeder')
+const InSlot = require('../../src/slots/InSlot')
 
 describe('the FloatInSlot class', () => {
 
@@ -41,6 +42,11 @@ describe('the FloatInSlot class', () => {
 
       expect(() => FloatInSlot.newAndAssertStructure(slotData)).toThrow(/min/)
     })
+
+    it('should allow for the display type "controller parameter"', () => {
+      const slotData = FloatInSlotSeeder.generate({ displayType: 'controller parameter' })
+      expect(() => FloatInSlot.newAndAssertStructure(slotData)).not.toThrow()
+    });
   })
 
   describe('.constructor', () => {

--- a/test/slots/OneOfInSlot.test.js
+++ b/test/slots/OneOfInSlot.test.js
@@ -23,20 +23,7 @@ describe('the OneOfInSlot class', () => {
       expect(slot.defaultValue).toBeNull()
     })
 
-    describe('.isControllerParameter', () => {
-      it('should return true for slots with the displayType controller paramter', () => {
-        const slot1 = new OneOfInSlot(
-          OneOfInSlotSeeder.generate({displayType: InSlot.CONTROLLER_PARAMETER_DISPLAY_TYPE })
-        )
-        const slot2 = new OneOfInSlot(
-          OneOfInSlotSeeder.generate({displayType: 'temperature' })
-        )
 
-        expect(slot1.isControllerParameter).toBe(true)
-        expect(slot2.isControllerParameter).toBe(false)
-
-      });
-    })
 
   })
 })

--- a/test/slots/OneOfInSlot.test.js
+++ b/test/slots/OneOfInSlot.test.js
@@ -1,5 +1,6 @@
 const OneOfInSlot = require('slots/OneOfInSlot')
 const { OneOfInSlotSeeder } = require('seeders/slots')
+const InSlot = require('../../src/slots/InSlot')
 
 describe('the OneOfInSlot class', () => {
   describe('.constructor', () => {
@@ -21,5 +22,21 @@ describe('the OneOfInSlot class', () => {
       const slot = new OneOfInSlot(slotData)
       expect(slot.defaultValue).toBeNull()
     })
+
+    describe('.isControllerParameter', () => {
+      it('should return true for slots with the displayType controller paramter', () => {
+        const slot1 = new OneOfInSlot(
+          OneOfInSlotSeeder.generate({displayType: InSlot.CONTROLLER_PARAMETER_DISPLAY_TYPE })
+        )
+        const slot2 = new OneOfInSlot(
+          OneOfInSlotSeeder.generate({displayType: 'temperature' })
+        )
+
+        expect(slot1.isControllerParameter).toBe(true)
+        expect(slot2.isControllerParameter).toBe(false)
+
+      });
+    })
+
   })
 })


### PR DESCRIPTION
- Updates the Controller seeder to alwasy generate with the right display type 
- Changes the default displayTypes for slot to not include `controller parameter`
- adds a new generated connected FctGraph to the tests

Reference for the connectedPIDFctGraphData

```javascript
const { functionalitySeeders,controllerSeeder,FCTGraphUtils, FCTGraph,Functionality, FCTGraphSeeder }  = require('@ospin/fct-graph')
const{ mutators: {
  addIntervalOutFctForAllOutSlotsWhichHaveNone,
  addPushInFctForAllInSlotsWhichHaveNone,
},} = FCTGraphUtils
const temperatureSensor = functionalitySeeders.TemperatureSensorSeeder.generateCelsiusFloatProducer()
const PIDController = functionalitySeeders.PIDControllerSeeder.generateTemperatureControllerCelsius()
const heaterData = functionalitySeeders.HeaterActuatorSeeder.generateCelsiusHeater()
const fctGraph = FCTGraphSeeder.seedOne({
  functionalities: [
    temperatureSensor,
    PIDController,
    heaterData
  ]
})

const temperature = fctGraph.getFctById(temperatureSensor.id)
const pid = fctGraph.getFctById(PIDController.id)
const heater = fctGraph.getFctById(heaterData.id)


temperature.getSlotByName('Celsius Out').connectTo(pid.getSlotByName('value in'))
heater.getSlotByName('Celsius In').connectTo(pid.getSlotByName('value out'))

addIntervalOutFctForAllOutSlotsWhichHaveNone(fctGraph, { customData: { destination: { name: 'ospin-webapp' } } })
addPushInFctForAllInSlotsWhichHaveNone(fctGraph, { customData: { source: { name: 'ospin-webapp' } } })

console.log(JSON.stringify(fctGraph));
```