### PR TITLE
refactor: changes default slot units on IONodes to "any"; throws errors when `Slot.connectTo` fails

### DIFF
--- a/src/fctGraph/FCTGraph.js
+++ b/src/fctGraph/FCTGraph.js
@@ -246,6 +246,11 @@ class FCTGraph {
     }
   }
 
+  getDisconnectedIONodeFcts() {
+    const fcts = this.getIONodeFcts()
+    return fcts.filter(fct => !fct.isConnected)
+  }
+
 }
 
 module.exports = (

--- a/src/fctGraph/FCTGraph.js
+++ b/src/fctGraph/FCTGraph.js
@@ -28,7 +28,7 @@ class FCTGraph {
     })
   }
 
-  static _collectUniqueDataStreamsDataFromFctData(functionalitiesData) {
+  static collectUniqueDataStreamsDataFromFctData(functionalitiesData) {
     const uniqueDataStreamsDataById = {}
 
     functionalitiesData.forEach(({ slots }) => {
@@ -64,7 +64,7 @@ class FCTGraph {
   }
 
   _populateConnectionsFromFctData(functionalitiesData) {
-    const dataStreamsData = FCTGraph._collectUniqueDataStreamsDataFromFctData(functionalitiesData)
+    const dataStreamsData = FCTGraph.collectUniqueDataStreamsDataFromFctData(functionalitiesData)
 
     this._addManyConnectionsViaDataStreamsData(dataStreamsData)
   }

--- a/src/fctGraph/Utils/mutators/addOutputFctForOutSlotWhichHasNone.js
+++ b/src/fctGraph/Utils/mutators/addOutputFctForOutSlotWhichHasNone.js
@@ -51,7 +51,7 @@ function addOutputFctForOutSlotWhichHasNone(fctGraph, outSlot, SubTypeClass, opt
     dataType: outSlot.dataType,
     name: OutputNode.SLOT_NAME,
     displayType: outSlot.displayType,
-    unit: outSlot.unit,
+    unit: OutSlot.ANY_UNIT_STRING,
     dataStreams: [],
   }
 

--- a/src/fctGraph/Utils/mutators/addPushInFctForInSlotWhichHasNone.js
+++ b/src/fctGraph/Utils/mutators/addPushInFctForInSlotWhichHasNone.js
@@ -56,7 +56,7 @@ function addPushInFctForInSlotWhichHasNone(fctGraph, inSlot, opts = DEFAULT_OPTS
     dataType: inSlot.dataType,
     name: PushIn.SLOT_NAME,
     displayType: inSlot.displayType,
-    unit: inSlot.unit,
+    unit: InSlot.ANY_UNIT_STRING,
     dataStreams: [],
   }
 

--- a/src/functionalities/Functionality.js
+++ b/src/functionalities/Functionality.js
@@ -196,6 +196,10 @@ class Functionality {
     return this._getConnectedFcts()
   }
 
+  get isConnected() {
+    return this.connectedFcts.length > 0
+  }
+
   get sources() {
     return this._getConnectedFcts(this.inSlots)
   }

--- a/src/seeders/functionalities/IntervalOutSeeder.js
+++ b/src/seeders/functionalities/IntervalOutSeeder.js
@@ -1,12 +1,16 @@
 const OutputNodeSeeder = require('./OutputNodeSeeder')
 const { FloatInSlotSeeder } = require('../slots')
 const IntervalOut = require('../../functionalities/IntervalOut')
+const Slot = require('../../slots/Slot')
 
 class IntervalOutSeeder extends OutputNodeSeeder {
 
   static generateSlots() {
     return [
-      FloatInSlotSeeder.generate({ name: IntervalOut.SLOT_NAME }),
+      FloatInSlotSeeder.generate({
+        name: IntervalOut.SLOT_NAME,
+        unit: Slot.ANY_UNIT_STRING,
+      }),
     ]
   }
 

--- a/src/seeders/functionalities/PushInSeeder.js
+++ b/src/seeders/functionalities/PushInSeeder.js
@@ -1,16 +1,19 @@
 const InputNodeSeeder = require('./InputNodeSeeder')
 const {
-  RandomSlotSeeder,
   IntegerOutSlotSeeder,
   FloatOutSlotSeeder,
 } = require('../slots')
 const PushIn = require('../../functionalities/PushIn')
+const Slot = require('../../slots/Slot')
 
 class PushInSeeder extends InputNodeSeeder {
 
   static generateSlots() {
     return [
-      RandomSlotSeeder.generateRandomOutSlot({ name: PushIn.SLOT_NAME }),
+      FloatOutSlotSeeder.generate({
+        name: PushIn.SLOT_NAME,
+        unit: Slot.ANY_UNIT_STRING,
+      }),
     ]
   }
 

--- a/src/seeders/functionalities/PushOutSeeder.js
+++ b/src/seeders/functionalities/PushOutSeeder.js
@@ -1,15 +1,18 @@
 const OutputNodeSeeder = require('./OutputNodeSeeder')
 const {
   FloatInSlotSeeder,
-  RandomSlotSeeder,
 } = require('../slots')
 const PushOut = require('../../functionalities/PushOut')
+const Slot = require('../../slots/Slot')
 
 class PushOutSeeder extends OutputNodeSeeder {
 
   static generateSlots() {
     return [
-      RandomSlotSeeder.generateRandomInSlot({ name: PushOut.SLOT_NAME }),
+      FloatInSlotSeeder.generate({
+        name: PushOut.SLOT_NAME,
+        unit: Slot.ANY_UNIT_STRING,
+      }),
     ]
   }
 

--- a/src/slots/Slot.js
+++ b/src/slots/Slot.js
@@ -162,17 +162,12 @@ class Slot {
     otherSlot._addDataStream(dataStream)
   }
 
-  // safe - returns a public response
   connectTo(otherSlot, dataStreamData = {}) {
-    try {
-      Slot._assertConnectionBetweenIsPossible(this, otherSlot)
-      const dataStream = this._createDataStreamTo(otherSlot, dataStreamData)
-      this._connectTo(otherSlot, dataStream)
+    Slot._assertConnectionBetweenIsPossible(this, otherSlot)
+    const dataStream = this._createDataStreamTo(otherSlot, dataStreamData)
+    this._connectTo(otherSlot, dataStream)
 
-      return publicSuccessRes({ thisSlot: this, otherSlot, dataStream })
-    } catch (e) {
-      return publicErrorRes({ errorMsg: e.message, thisSlot: this, otherSlot, dataStream: null })
-    }
+    return { thisSlot: this, otherSlot, dataStream }
   }
 
   filterConnectableSlots(slots) {

--- a/test/fctGraph/FCTGraph.test.js
+++ b/test/fctGraph/FCTGraph.test.js
@@ -129,7 +129,7 @@ describe('the FCTGraph class', () => {
 
       expect(unconnectedFctGraph.dataStreamsCount).toBe(0)
 
-      const dataStreams = FCTGraph._collectUniqueDataStreamsDataFromFctData(
+      const dataStreams = FCTGraph.collectUniqueDataStreamsDataFromFctData(
         connectedFCTGraphData.functionalities,
       )
 

--- a/test/fctGraph/FCTGraph.test.js
+++ b/test/fctGraph/FCTGraph.test.js
@@ -603,4 +603,28 @@ describe('the FCTGraph class', () => {
       expect(fcts[0].id).toBe(inputFct.id)
     })
   })
+
+  describe('getDisconnectedIONodeFcts', () => {
+    it('should return all disconnected IONode fcts', () => {
+      const inputData = PushInSeeder.generate()
+      const pushOutputData = PushOutSeeder.generateFloatPushOutCelsius()
+      const intervalOutData = IntervalOutSeeder.generate()
+      const tempSensorData = TemperatureSensorSeeder.generateCelsiusFloatProducer()
+
+      const fctGraph = FCTGraphSeeder
+        .seedOne(
+          { functionalities: [ inputData, pushOutputData, intervalOutData, tempSensorData ] },
+        )
+
+      const pushOut = fctGraph.getFctById(pushOutputData.id)
+      const tempSensor = fctGraph.getFctById(tempSensorData.id)
+
+      const tempOutSlot = tempSensor.slots[0]
+      const pushOutSlot = pushOut.slots[0]
+
+      tempOutSlot.connectTo(pushOutSlot)
+
+      expect(fctGraph.getDisconnectedIONodeFcts()).toHaveLength(2)
+    })
+  })
 })

--- a/test/fctGraph/utils/mutators/addIntervalOutFctForOutSlotWhichHasNone.test.js
+++ b/test/fctGraph/utils/mutators/addIntervalOutFctForOutSlotWhichHasNone.test.js
@@ -46,7 +46,6 @@ describe('addIntervalOutFctForOutSlotWhichHasNone', () => {
       const [ temperatureSensor, intervalOutFct ] = fctGraph.functionalities
       const { error } = temperatureSensor.outSlots[0].connectTo(intervalOutFct.inSlots[0])
 
-      expect(error).toBe(false)
       expect(
         () => addIntervalOutFctForOutSlotWhichHasNone(fctGraph, temperatureSensor.outSlots[0]),
       ).toThrow(/already has a connected OutputNode/)
@@ -65,12 +64,8 @@ describe('addIntervalOutFctForOutSlotWhichHasNone', () => {
         const errorMsg = 'no!'
         tempSensorOutSlot._connectTo = () => { throw new Error(errorMsg) }
 
-        const { error, errorMsg: receivedErrorMsg } = (
-          addIntervalOutFctForOutSlotWhichHasNone(fctGraph, tempSensorOutSlot)
-        )
-
-        expect(error).toBe(true)
-        expect(receivedErrorMsg).toStrictEqual(errorMsg)
+        expect(() => addIntervalOutFctForOutSlotWhichHasNone(fctGraph, tempSensorOutSlot))
+          .toThrow(errorMsg)
       })
     })
   })

--- a/test/fctGraph/utils/mutators/addPushInFctForInSlotWhichHasNone.test.js
+++ b/test/fctGraph/utils/mutators/addPushInFctForInSlotWhichHasNone.test.js
@@ -48,9 +48,8 @@ describe('addPushInFctForInSlotWhichHasNone', () => {
       })
 
       const [ heaterActuator, pushInFct ] = fctGraph.functionalities
-      const { error } = heaterActuator.inSlots[0].connectTo(pushInFct.outSlots[0])
+      heaterActuator.inSlots[0].connectTo(pushInFct.outSlots[0])
 
-      expect(error).toBe(false)
       expect(
         () => addPushInFctForInSlotWhichHasNone(fctGraph, heaterActuator.inSlots[0]),
       ).toThrow(/already has a connected InputNode/)
@@ -69,12 +68,8 @@ describe('addPushInFctForInSlotWhichHasNone', () => {
         const errorMsg = 'no!'
         heatActuatorInSlot._connectTo = () => { throw new Error(errorMsg) }
 
-        const { error, errorMsg: receivedErrorMsg } = (
-          addPushInFctForInSlotWhichHasNone(fctGraph, heatActuatorInSlot)
-        )
-
-        expect(error).toBe(true)
-        expect(receivedErrorMsg).toStrictEqual(errorMsg)
+        expect(() => addPushInFctForInSlotWhichHasNone(fctGraph, heatActuatorInSlot))
+          .toThrow(errorMsg)
       })
     })
   })

--- a/test/fctGraph/utils/mutators/addPushOutFctForOutSlotWhichHasNone.test.js
+++ b/test/fctGraph/utils/mutators/addPushOutFctForOutSlotWhichHasNone.test.js
@@ -46,7 +46,6 @@ describe('addPushOutFctForOutSlotWhichHasNone', () => {
       const [ temperatureSensor, pushOutFct ] = fctGraph.functionalities
       const { error } = temperatureSensor.outSlots[0].connectTo(pushOutFct.inSlots[0])
 
-      expect(error).toBe(false)
       expect(
         () => addPushOutFctForOutSlotWhichHasNone(fctGraph, temperatureSensor.outSlots[0]),
       ).toThrow(/already has a connected OutputNode/)
@@ -65,12 +64,8 @@ describe('addPushOutFctForOutSlotWhichHasNone', () => {
         const errorMsg = 'no!'
         tempSensorOutSlot._connectTo = () => { throw new Error(errorMsg) }
 
-        const { error, errorMsg: receivedErrorMsg } = (
-          addPushOutFctForOutSlotWhichHasNone(fctGraph, tempSensorOutSlot)
-        )
-
-        expect(error).toBe(true)
-        expect(receivedErrorMsg).toStrictEqual(errorMsg)
+        expect(() => addPushOutFctForOutSlotWhichHasNone(fctGraph, tempSensorOutSlot))
+          .toThrow(errorMsg)
       })
     })
   })

--- a/test/functionalities/Functionality.test.js
+++ b/test/functionalities/Functionality.test.js
@@ -163,6 +163,29 @@ describe('the Functionality class', () => {
       })
     })
 
+    describe('.isConnected', () => {
+      it('returns true for a connected fct', () => {
+        const pidController = PIDControllerSeeder.seedOne(
+          PIDControllerSeeder.generateTemperatureControllerCelsius(),
+        )
+        const tempSensor = TemperatureSensorSeeder.seedOne(
+          TemperatureSensorSeeder.generateCelsiusFloatProducer(),
+        )
+
+        tempSensor.outSlots[0].connectTo(pidController.getSlotByName('value in'))
+
+        expect(tempSensor.isConnected).toBe(true)
+      })
+
+      it('returns false for a disconnected fct', () => {
+        const tempSensor = TemperatureSensorSeeder.seedOne(
+          TemperatureSensorSeeder.generateCelsiusFloatProducer(),
+        )
+
+        expect(tempSensor.isConnected).toBe(false)
+      })
+    })
+
     describe('.sources', () => {
       it('all fcts connected via inslots', () => {
         const heater = HeaterActuatorSeeder.seedOne(

--- a/test/slots/Slot.test.js
+++ b/test/slots/Slot.test.js
@@ -146,15 +146,8 @@ describe('the Slot class', () => {
       FloatInSlotSeeder.stubOwningFct(slotB)
 
       const dataStreamOpts = { averagingWindowSize: 10 }
-      const {
-        error,
-        errorMsg,
-        thisSlot,
-        otherSlot,
-      } = slotA.connectTo(slotB, dataStreamOpts)
+      const { thisSlot, otherSlot } = slotA.connectTo(slotB, dataStreamOpts)
 
-      expect(error).toBe(false)
-      expect(errorMsg).toBeNull()
       expect(thisSlot.dataStreams).toStrictEqual(otherSlot.dataStreams)
       expect(thisSlot.dataStreams[0].averagingWindowSize).toBe(dataStreamOpts.averagingWindowSize)
     })
@@ -166,10 +159,8 @@ describe('the Slot class', () => {
       FloatOutSlotSeeder.stubOwningFct(slotA)
       FloatInSlotSeeder.stubOwningFct(slotB)
 
-      const { error, errorMsg, thisSlot, otherSlot } = slotB.connectTo(slotA)
+      const { thisSlot, otherSlot } = slotB.connectTo(slotA)
 
-      expect(error).toBe(false)
-      expect(errorMsg).toBeNull()
       expect(thisSlot.dataStreams).toStrictEqual(otherSlot.dataStreams)
     })
 
@@ -177,34 +168,19 @@ describe('the Slot class', () => {
       const slotA = IntegerOutSlotSeeder.seedCelsiusOut()
       const slotB = FloatInSlotSeeder.seedCelsiusIn()
 
-      const { error, errorMsg } = slotA.connectTo(slotB)
-
-      expect(error).toBe(true)
-      expect(errorMsg).toContain('dataTypes must match between slots')
+      expect(() => slotA.connectTo(slotB)).toThrow(/dataTypes must match between slots/)
     })
 
     it('returns an error when the slot types are incompatible', () => {
       const slotA = FloatOutSlotSeeder.seedCelsiusOut()
       const slotB = FloatOutSlotSeeder.seedCelsiusOut()
 
-      const {
-        error: outToOutError,
-        errorMsg: outToOutErrorMsg,
-      } = slotA.connectTo(slotB)
-
-      expect(outToOutError).toBe(true)
-      expect(outToOutErrorMsg).toContain('must have complimentary types')
+      expect(() => slotA.connectTo(slotB)).toThrow(/must have complimentary types/)
 
       const slot1 = FloatInSlotSeeder.seedCelsiusIn()
       const slot2 = FloatInSlotSeeder.seedCelsiusIn()
 
-      const {
-        error: inToInError,
-        errorMsg: inToInErrorMsgm,
-      } = slot1.connectTo(slot2)
-
-      expect(inToInError).toBe(true)
-      expect(inToInErrorMsgm).toContain('must have complimentary types')
+      expect(() => slot1.connectTo(slot2)).toThrow(/must have complimentary types/)
     })
 
     describe('when the units are not matching', () => {
@@ -212,37 +188,28 @@ describe('the Slot class', () => {
         const slotA = FloatOutSlotSeeder.seedCelsiusOut()
         const slotB = FloatInSlotSeeder.seedKelvinIn()
 
-        const { error, errorMsg } = slotA.connectTo(slotB)
-
-        expect(error).toBe(true)
-        expect(errorMsg).toContain('units must match between slots')
+        expect(() => slotA.connectTo(slotB)).toThrow(/units must match between slots/)
       })
 
       it(`does NOT return an error when slotA has ${Slot.ANY_UNIT_STRING} as unit`, () => {
         const slotA = FloatOutSlotSeeder.seedOne({ unit: Slot.ANY_UNIT_STRING })
         const slotB = FloatInSlotSeeder.seedKelvinIn()
 
-        const { error } = slotA.connectTo(slotB)
-
-        expect(error).toBe(false)
+        expect(() => slotA.connectTo(slotB)).not.toThrow()
       })
 
       it(`does NOT return an error when slotB has ${Slot.ANY_UNIT_STRING} as unit`, () => {
         const slotA = FloatInSlotSeeder.seedKelvinIn()
         const slotB = FloatOutSlotSeeder.seedOne({ unit: Slot.ANY_UNIT_STRING })
 
-        const { error } = slotA.connectTo(slotB)
-
-        expect(error).toBe(false)
+        expect(() => slotA.connectTo(slotB)).not.toThrow()
       })
 
       it(`does NOT return an error when slotA and slotB have ${Slot.ANY_UNIT_STRING} as unit`, () => {
         const slotA = FloatInSlotSeeder.seedOne({ unit: Slot.ANY_UNIT_STRING })
         const slotB = FloatOutSlotSeeder.seedOne({ unit: Slot.ANY_UNIT_STRING })
 
-        const { error } = slotA.connectTo(slotB)
-
-        expect(error).toBe(false)
+        expect(() => slotA.connectTo(slotB)).not.toThrow()
       })
     })
 
@@ -255,13 +222,8 @@ describe('the Slot class', () => {
 
       slotA.connectTo(slotB)
 
-      const { error: errorAToB, errorMsg: errorMsgAToB } = slotA.connectTo(slotB)
-      expect(errorAToB).toBe(true)
-      expect(errorMsgAToB).toContain('already connected to target slot')
-
-      const { error: errorBToA, errorMsg: errorMsgBToA } = slotB.connectTo(slotA)
-      expect(errorBToA).toBe(true)
-      expect(errorMsgBToA).toContain('already connected to target slot')
+      expect(() => slotA.connectTo(slotB)).toThrow(/already connected to target slot/)
+      expect(() => slotB.connectTo(slotA)).toThrow(/already connected to target slot/)
     })
 
     it('returns an error when the outslot already has a dataStream', () => {
@@ -274,10 +236,7 @@ describe('the Slot class', () => {
       FloatOutSlotSeeder.stubOwningFct(slotIn)
 
       outSlotA.connectTo(slotIn)
-
-      const { error, errorMsg } = outSlotB.connectTo(slotIn)
-      expect(error).toBe(true)
-      expect(errorMsg).toContain('can only have a single dataStream')
+      expect(() => outSlotB.connectTo(slotIn)).toThrow(/can only have a single dataStream/)
     })
   })
 


### PR DESCRIPTION
BREAKING CHANGE: Autopopulation of IONodes is now using `any` for the slot unit; `connectTo` is now throwing the error instead of catching it and returning a response. 
closes #125 
closes #123 
closes #122 
closes #91 