### PR TITLE
fix: do not set firmware blackbox default value to prevent comparison…

### DIFF
--- a/src/functionalities/Functionality.js
+++ b/src/functionalities/Functionality.js
@@ -30,7 +30,7 @@ const SCHEMA = Joi.object({
     .unique('name')
     .default([]),
   isVirtual: Joi.boolean().default(false),
-  firmwareBlackBox: Joi.object().default({}),
+  firmwareBlackBox: Joi.object(),
   outputIntervalMs: Joi.number()
     .integer()
     .strict()

--- a/test/functionalities/Functionality.test.js
+++ b/test/functionalities/Functionality.test.js
@@ -21,7 +21,6 @@ describe('Functionality', () => {
       expect(res).toStrictEqual(expect.objectContaining({
         slots: [],
         isVirtual: false,
-        firmwareBlackBox: {},
       }))
     })
 


### PR DESCRIPTION
… logic from not identifying equal graphs